### PR TITLE
Add java and dart languages

### DIFF
--- a/app/comparison/page.tsx
+++ b/app/comparison/page.tsx
@@ -8,6 +8,7 @@ import CodeMirror from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
 import { html } from "@codemirror/lang-html";
 import { go } from "@codemirror/lang-go";
+import { java } from "@codemirror/lang-java";
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import html2canvas from "html2canvas";
 import { useCodeImageStore } from "@/lib/store";
@@ -29,12 +30,17 @@ import { GradientSelector } from "@/components/ui/gradient-selector";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { BackgroundImageSelector } from "@/components/ui/background-image-selector";
 
-function getLanguageExtension(language: 'javascript' | 'html' | 'go') {
+function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 'dart') {
   switch (language) {
     case 'html':
       return html();
     case 'go':
       return go();
+    case 'java':
+      return java();
+    case 'dart':
+      // Dart uses JavaScript highlighting as a fallback since no official support exists
+      return javascript();
     case 'javascript':
     default:
       return javascript();
@@ -325,29 +331,30 @@ export default function CodeComparison() {
   const showControls = true;
 
   // State for left and right code snippets
-  const [leftCode, setLeftCode] = useState(`// JavaScript Example
-function greet(name) {
-  return \`Hello, \${name}!\`;
-}
-console.log(greet('World'));`);
-
-  const [rightCode, setRightCode] = useState(`// Go Example
-package main
-
-import "fmt"
-
-func greet(name string) string {
-	return fmt.Sprintf("Hello, %s!", name)
-}
-
-func main() {
-	fmt.Println(greet("World"))
+  const [leftCode, setLeftCode] = useState(`// Java Example
+public class Main {
+    public static String greet(String name) {
+        return "Hello, " + name + "!";
+    }
+    
+    public static void main(String[] args) {
+        System.out.println(greet("World"));
+    }
 }`);
 
-  const [leftTitle, setLeftTitle] = useState("JavaScript");
-  const [rightTitle, setRightTitle] = useState("Go");
-  const [leftLanguage, setLeftLanguage] = useState<SupportedLanguage>('javascript');
-  const [rightLanguage, setRightLanguage] = useState<SupportedLanguage>('go');
+  const [rightCode, setRightCode] = useState(`// Dart Example
+void main() {
+  print(greet('World'));
+}
+
+String greet(String name) {
+  return 'Hello, \$name!';
+}`);
+
+  const [leftTitle, setLeftTitle] = useState("Java");
+  const [rightTitle, setRightTitle] = useState("Dart");
+  const [leftLanguage, setLeftLanguage] = useState<SupportedLanguage>('java');
+  const [rightLanguage, setRightLanguage] = useState<SupportedLanguage>('dart');
 
   // Debounce for code editors
   const debouncedSetLeftCode = debounce((value: string) => setLeftCode(value), 300);
@@ -764,6 +771,8 @@ func main() {
                         <SelectItem value="javascript" className="text-gray-100 hover:bg-gray-700">JavaScript</SelectItem>
                         <SelectItem value="html" className="text-gray-100 hover:bg-gray-700">HTML</SelectItem>
                         <SelectItem value="go" className="text-gray-100 hover:bg-gray-700">Go</SelectItem>
+                        <SelectItem value="java" className="text-gray-100 hover:bg-gray-700">Java</SelectItem>
+                        <SelectItem value="dart" className="text-gray-100 hover:bg-gray-700">Dart</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -780,6 +789,8 @@ func main() {
                         <SelectItem value="javascript" className="text-gray-100 hover:bg-gray-700">JavaScript</SelectItem>
                         <SelectItem value="html" className="text-gray-100 hover:bg-gray-700">HTML</SelectItem>
                         <SelectItem value="go" className="text-gray-100 hover:bg-gray-700">Go</SelectItem>
+                        <SelectItem value="java" className="text-gray-100 hover:bg-gray-700">Java</SelectItem>
+                        <SelectItem value="dart" className="text-gray-100 hover:bg-gray-700">Dart</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/app/comparison/page.tsx
+++ b/app/comparison/page.tsx
@@ -9,6 +9,10 @@ import { javascript } from "@codemirror/lang-javascript";
 import { html } from "@codemirror/lang-html";
 import { go } from "@codemirror/lang-go";
 import { java } from "@codemirror/lang-java";
+import { php } from "@codemirror/lang-php";
+import { StreamLanguage } from "@codemirror/language";
+import { swift } from "@codemirror/legacy-modes/mode/swift";
+import { kotlin } from "@codemirror/legacy-modes/mode/clike";
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import html2canvas from "html2canvas";
 import { useCodeImageStore } from "@/lib/store";
@@ -30,7 +34,7 @@ import { GradientSelector } from "@/components/ui/gradient-selector";
 import { ColorPicker } from "@/components/ui/color-picker";
 import { BackgroundImageSelector } from "@/components/ui/background-image-selector";
 
-function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 'dart') {
+function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 'dart' | 'kotlin' | 'swift' | 'php') {
   switch (language) {
     case 'html':
       return html();
@@ -41,6 +45,12 @@ function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 
     case 'dart':
       // Dart uses JavaScript highlighting as a fallback since no official support exists
       return javascript();
+    case 'kotlin':
+      return StreamLanguage.define(kotlin);
+    case 'swift':
+      return StreamLanguage.define(swift);
+    case 'php':
+      return php();
     case 'javascript':
     default:
       return javascript();
@@ -331,30 +341,26 @@ export default function CodeComparison() {
   const showControls = true;
 
   // State for left and right code snippets
-  const [leftCode, setLeftCode] = useState(`// Java Example
-public class Main {
-    public static String greet(String name) {
-        return "Hello, " + name + "!";
-    }
-    
-    public static void main(String[] args) {
-        System.out.println(greet("World"));
-    }
-}`);
-
-  const [rightCode, setRightCode] = useState(`// Dart Example
-void main() {
-  print(greet('World'));
+  const [leftCode, setLeftCode] = useState(`// Kotlin Example
+fun greet(name: String): String {
+    return "Hello, \$name!"
 }
 
-String greet(String name) {
-  return 'Hello, \$name!';
+fun main() {
+    println(greet("World"))
 }`);
 
-  const [leftTitle, setLeftTitle] = useState("Java");
-  const [rightTitle, setRightTitle] = useState("Dart");
-  const [leftLanguage, setLeftLanguage] = useState<SupportedLanguage>('java');
-  const [rightLanguage, setRightLanguage] = useState<SupportedLanguage>('dart');
+  const [rightCode, setRightCode] = useState(`// Swift Example
+func greet(_ name: String) -> String {
+    return "Hello, \\(name)!"
+}
+
+print(greet("World"))`);
+
+  const [leftTitle, setLeftTitle] = useState("Kotlin");
+  const [rightTitle, setRightTitle] = useState("Swift");
+  const [leftLanguage, setLeftLanguage] = useState<SupportedLanguage>('kotlin');
+  const [rightLanguage, setRightLanguage] = useState<SupportedLanguage>('swift');
 
   // Debounce for code editors
   const debouncedSetLeftCode = debounce((value: string) => setLeftCode(value), 300);
@@ -764,7 +770,7 @@ String greet(String name) {
                       Left Language
                     </Label>
                     <Select value={leftLanguage} onValueChange={(value) => setLeftLanguage(value as SupportedLanguage)}>
-                      <SelectTrigger id="leftLanguage" className="text-sm bg-gray-800 border-gray-700 text-gray-100">
+                      <SelectTrigger id="leftLanguage" className="w-full text-sm bg-gray-800 border-gray-700 text-gray-100">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent className="bg-gray-800 border-gray-700">
@@ -773,6 +779,9 @@ String greet(String name) {
                         <SelectItem value="go" className="text-gray-100 hover:bg-gray-700">Go</SelectItem>
                         <SelectItem value="java" className="text-gray-100 hover:bg-gray-700">Java</SelectItem>
                         <SelectItem value="dart" className="text-gray-100 hover:bg-gray-700">Dart</SelectItem>
+                        <SelectItem value="kotlin" className="text-gray-100 hover:bg-gray-700">Kotlin</SelectItem>
+                        <SelectItem value="swift" className="text-gray-100 hover:bg-gray-700">Swift</SelectItem>
+                        <SelectItem value="php" className="text-gray-100 hover:bg-gray-700">PHP</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -782,7 +791,7 @@ String greet(String name) {
                       Right Language
                     </Label>
                     <Select value={rightLanguage} onValueChange={(value) => setRightLanguage(value as SupportedLanguage)}>
-                      <SelectTrigger id="rightLanguage" className="text-sm bg-gray-800 border-gray-700 text-gray-100">
+                      <SelectTrigger id="rightLanguage" className="w-full text-sm bg-gray-800 border-gray-700 text-gray-100">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent className="bg-gray-800 border-gray-700">
@@ -791,6 +800,9 @@ String greet(String name) {
                         <SelectItem value="go" className="text-gray-100 hover:bg-gray-700">Go</SelectItem>
                         <SelectItem value="java" className="text-gray-100 hover:bg-gray-700">Java</SelectItem>
                         <SelectItem value="dart" className="text-gray-100 hover:bg-gray-700">Dart</SelectItem>
+                        <SelectItem value="kotlin" className="text-gray-100 hover:bg-gray-700">Kotlin</SelectItem>
+                        <SelectItem value="swift" className="text-gray-100 hover:bg-gray-700">Swift</SelectItem>
+                        <SelectItem value="php" className="text-gray-100 hover:bg-gray-700">PHP</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import CodeMirror from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
 import { html } from "@codemirror/lang-html";
 import { go } from "@codemirror/lang-go";
+import { java } from "@codemirror/lang-java";
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import html2canvas from "html2canvas";
 import { useCodeImageStore } from "@/lib/store";
@@ -22,12 +23,17 @@ import Image from "next/image";
 import { ControlsPanel, SupportedLanguage } from "@/components/controls-panel";
 import { createPortal } from "react-dom";
 
-function getLanguageExtension(language: 'javascript' | 'html' | 'go') {
+function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 'dart') {
   switch (language) {
     case 'html':
       return html();
     case 'go':
       return go();
+    case 'java':
+      return java();
+    case 'dart':
+      // Dart uses JavaScript highlighting as a fallback since no official support exists
+      return javascript();
     case 'javascript':
     default:
       return javascript();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,10 @@ import { javascript } from "@codemirror/lang-javascript";
 import { html } from "@codemirror/lang-html";
 import { go } from "@codemirror/lang-go";
 import { java } from "@codemirror/lang-java";
+import { php } from "@codemirror/lang-php";
+import { StreamLanguage } from "@codemirror/language";
+import { swift } from "@codemirror/legacy-modes/mode/swift";
+import { kotlin } from "@codemirror/legacy-modes/mode/clike";
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import html2canvas from "html2canvas";
 import { useCodeImageStore } from "@/lib/store";
@@ -23,7 +27,7 @@ import Image from "next/image";
 import { ControlsPanel, SupportedLanguage } from "@/components/controls-panel";
 import { createPortal } from "react-dom";
 
-function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 'dart') {
+function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 'dart' | 'kotlin' | 'swift' | 'php') {
   switch (language) {
     case 'html':
       return html();
@@ -34,6 +38,12 @@ function getLanguageExtension(language: 'javascript' | 'html' | 'go' | 'java' | 
     case 'dart':
       // Dart uses JavaScript highlighting as a fallback since no official support exists
       return javascript();
+    case 'kotlin':
+      return StreamLanguage.define(kotlin);
+    case 'swift':
+      return StreamLanguage.define(swift);
+    case 'php':
+      return php();
     case 'javascript':
     default:
       return javascript();

--- a/components/controls-panel.tsx
+++ b/components/controls-panel.tsx
@@ -51,20 +51,6 @@ export function ControlsPanel({ selectedLanguage, onSelectedLanguageChange }: Co
   return (
     <div className="p-4 space-y-6 h-full overflow-y-auto">
 
-      {/* Watermark Text */}
-      <div className="space-y-2">
-        <Label htmlFor="watermark" className="text-xs font-medium text-muted-foreground">
-          Watermark Text
-        </Label>
-        <Input
-          id="watermark"
-          value={watermark}
-          onChange={(e) => setWatermark(e.target.value)}
-          placeholder="@yourhandle or yoursite.com"
-          className="text-sm bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400"
-        />
-      </div>
-
       {/* Display Title */}
       <div className="space-y-2">
         <Label htmlFor="displayTitle" className="text-xs font-medium text-muted-foreground">
@@ -89,6 +75,20 @@ export function ControlsPanel({ selectedLanguage, onSelectedLanguageChange }: Co
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Window title"
+          className="text-sm bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400"
+        />
+      </div>
+
+      {/* Watermark Text */}
+      <div className="space-y-2">
+        <Label htmlFor="watermark" className="text-xs font-medium text-muted-foreground">
+          Watermark Text
+        </Label>
+        <Input
+          id="watermark"
+          value={watermark}
+          onChange={(e) => setWatermark(e.target.value)}
+          placeholder="@yourhandle or yoursite.com"
           className="text-sm bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400"
         />
       </div>

--- a/components/controls-panel.tsx
+++ b/components/controls-panel.tsx
@@ -9,7 +9,7 @@ import { ColorPicker } from "@/components/ui/color-picker";
 import { BackgroundImageSelector } from "@/components/ui/background-image-selector";
 import { useCodeImageStore } from "@/lib/store";
 
-export type SupportedLanguage = 'javascript' | 'html' | 'go' | 'java' | 'dart';
+export type SupportedLanguage = 'javascript' | 'html' | 'go' | 'java' | 'dart' | 'kotlin' | 'swift' | 'php';
 
 type ControlsPanelProps = {
   selectedLanguage: SupportedLanguage;
@@ -99,7 +99,7 @@ export function ControlsPanel({ selectedLanguage, onSelectedLanguageChange }: Co
           Programming Language
         </Label>
         <Select value={selectedLanguage} onValueChange={(value) => onSelectedLanguageChange(value as SupportedLanguage)}>
-          <SelectTrigger id="language" className="text-sm bg-gray-800 border-gray-700 text-gray-100">
+          <SelectTrigger id="language" className="w-full text-sm bg-gray-800 border-gray-700 text-gray-100">
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="bg-gray-800 border-gray-700">
@@ -108,6 +108,9 @@ export function ControlsPanel({ selectedLanguage, onSelectedLanguageChange }: Co
             <SelectItem value="go" className="text-gray-100 hover:bg-gray-700">Go</SelectItem>
             <SelectItem value="java" className="text-gray-100 hover:bg-gray-700">Java</SelectItem>
             <SelectItem value="dart" className="text-gray-100 hover:bg-gray-700">Dart</SelectItem>
+            <SelectItem value="kotlin" className="text-gray-100 hover:bg-gray-700">Kotlin</SelectItem>
+            <SelectItem value="swift" className="text-gray-100 hover:bg-gray-700">Swift</SelectItem>
+            <SelectItem value="php" className="text-gray-100 hover:bg-gray-700">PHP</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/components/controls-panel.tsx
+++ b/components/controls-panel.tsx
@@ -9,7 +9,7 @@ import { ColorPicker } from "@/components/ui/color-picker";
 import { BackgroundImageSelector } from "@/components/ui/background-image-selector";
 import { useCodeImageStore } from "@/lib/store";
 
-export type SupportedLanguage = 'javascript' | 'html' | 'go';
+export type SupportedLanguage = 'javascript' | 'html' | 'go' | 'java' | 'dart';
 
 type ControlsPanelProps = {
   selectedLanguage: SupportedLanguage;
@@ -106,6 +106,8 @@ export function ControlsPanel({ selectedLanguage, onSelectedLanguageChange }: Co
             <SelectItem value="javascript" className="text-gray-100 hover:bg-gray-700">JavaScript</SelectItem>
             <SelectItem value="html" className="text-gray-100 hover:bg-gray-700">HTML</SelectItem>
             <SelectItem value="go" className="text-gray-100 hover:bg-gray-700">Go</SelectItem>
+            <SelectItem value="java" className="text-gray-100 hover:bg-gray-700">Java</SelectItem>
+            <SelectItem value="dart" className="text-gray-100 hover:bg-gray-700">Dart</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@codemirror/lang-python": "^6.2.0",
         "@codemirror/lang-rust": "^6.0.1",
         "@codemirror/lang-sql": "^6.8.0",
+        "@codemirror/legacy-modes": "^6.5.1",
         "@radix-ui/react-label": "^2.1.4",
         "@radix-ui/react-select": "^2.2.2",
         "@radix-ui/react-slider": "^1.3.2",
@@ -285,6 +286,15 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.1.tgz",
+      "integrity": "sha512-DJYQQ00N1/KdESpZV7jg9hafof/iBNp9h7TYo1SLMk86TWl9uDsVdho2dzd81K+v4retmK6mdC7WpuOQDytQqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@codemirror/lang-python": "^6.2.0",
     "@codemirror/lang-rust": "^6.0.1",
     "@codemirror/lang-sql": "^6.8.0",
+    "@codemirror/legacy-modes": "^6.5.1",
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slider": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,6 +181,13 @@
     "@lezer/lr" "^1.0.0"
     style-mod "^4.0.0"
 
+"@codemirror/legacy-modes@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.1.tgz"
+  integrity sha512-DJYQQ00N1/KdESpZV7jg9hafof/iBNp9h7TYo1SLMk86TWl9uDsVdho2dzd81K+v4retmK6mdC7WpuOQDytQqw==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+
 "@codemirror/lint@^6.0.0":
   version "6.8.5"
   resolved "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz"


### PR DESCRIPTION
Add Java and Dart language support to the code snippet application.

Java support utilizes the official `@codemirror/lang-java` package. For Dart, as no official CodeMirror 6 package is available, JavaScript highlighting is used as a fallback due to its syntactic similarities. This PR also updates UI language selectors and default code examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f44271e-c19e-4efd-809f-f686467f5963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f44271e-c19e-4efd-809f-f686467f5963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

